### PR TITLE
Removing numpy and pandas dependencies

### DIFF
--- a/{{cookiecutter.github_project_name}}/setup.py
+++ b/{{cookiecutter.github_project_name}}/setup.py
@@ -130,8 +130,7 @@ setup_args = {
     ],
     'install_requires': [
         'ipywidgets>=5.1.3',
-        'numpy',
-        'pandas'],
+    ],
     'packages': find_packages(),
     'zip_safe': False,
     'cmdclass': {


### PR DESCRIPTION
These seems like some heavyweight dependencies for a baseline widget... especially since interacting with them from the widget world is [not uniformly defined yet](https://github.com/ipython/traitlets/issues/48)!